### PR TITLE
Add persistent render cache and map analysis

### DIFF
--- a/CitySimulator/src/app/app_launcher.cpp
+++ b/CitySimulator/src/app/app_launcher.cpp
@@ -17,12 +17,14 @@
 // Store models
 #include <core/store_models/vehicle_analyze_data.h>
 #include <data/map_renderer_data.h>
+#include <data/persistent_render_data.h>
 
 namespace tjs {
 
 	void setup_store_models(Application& app) {
 		app.stores().add_model<core::model::VehicleAnalyzeData>();
 		app.stores().add_model<core::model::MapRendererData>();
+		app.stores().add_model<core::model::PersistentRenderData>();
 	}
 
 	int launch(int argc, char* argv[]) {

--- a/CitySimulator/src/app/data/persistent_render_data.cpp
+++ b/CitySimulator/src/app/data/persistent_render_data.cpp
@@ -1,0 +1,65 @@
+#include "stdafx.h"
+#include "data/persistent_render_data.h"
+#include "visualization/elements/map_element.h"
+#include "Application.h"
+
+#include <core/data_layer/world_data.h>
+
+namespace tjs::visualization {
+
+	void recalculate_map_data(Application& app) {
+		auto* cache = app.stores().get_model<core::model::PersistentRenderData>();
+		auto* render = app.stores().get_model<core::model::MapRendererData>();
+		if (!cache || !render) {
+			return;
+		}
+
+		cache->nodes.clear();
+		cache->ways.clear();
+		cache->vehicles.clear();
+		cache->selectedNode = nullptr;
+
+		if (app.worldData().segments().empty()) {
+			return;
+		}
+
+		auto& segment = *app.worldData().segments().front();
+
+		for (auto& [uid, nodePtr] : segment.nodes) {
+			core::model::NodeRenderInfo info;
+			info.node = nodePtr.get();
+			info.screenPos = convert_to_screen(
+				nodePtr->coordinates,
+				render->projectionCenter,
+				render->screen_center,
+				render->metersPerPixel);
+			cache->nodes.emplace(uid, info);
+		}
+
+		for (auto& [uid, wayPtr] : segment.ways) {
+			core::model::WayRenderInfo info;
+			info.way = wayPtr.get();
+			info.screenPoints.reserve(wayPtr->nodes.size());
+			for (auto* node : wayPtr->nodes) {
+				info.screenPoints.push_back(convert_to_screen(
+					node->coordinates,
+					render->projectionCenter,
+					render->screen_center,
+					render->metersPerPixel));
+			}
+			cache->ways.emplace(uid, std::move(info));
+		}
+
+		for (auto& vehicle : app.worldData().vehicles()) {
+			core::model::VehicleRenderInfo info;
+			info.vehicle = &vehicle;
+			info.screenPos = convert_to_screen(
+				vehicle.coordinates,
+				render->projectionCenter,
+				render->screen_center,
+				render->metersPerPixel);
+			cache->vehicles.push_back(info);
+		}
+	}
+
+} // namespace tjs::visualization

--- a/CitySimulator/src/app/data/persistent_render_data.h
+++ b/CitySimulator/src/app/data/persistent_render_data.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <core/store_models/idata_model.h>
+#include <core/data_layer/data_types.h>
+#include <render/render_primitives.h>
+#include <unordered_map>
+#include <vector>
+
+namespace tjs::core::model {
+
+	struct NodeRenderInfo {
+		core::Node* node = nullptr;
+		tjs::Position screenPos {};
+		bool selected = false;
+	};
+
+	struct WayRenderInfo {
+		core::WayInfo* way = nullptr;
+		std::vector<tjs::Position> screenPoints;
+		bool selected = false;
+	};
+
+	struct VehicleRenderInfo {
+		core::Vehicle* vehicle = nullptr;
+		tjs::Position screenPos {};
+	};
+
+	struct PersistentRenderData : public IDataModel {
+		static std::type_index get_type() { return typeid(PersistentRenderData); }
+
+		std::unordered_map<uint64_t, NodeRenderInfo> nodes;
+		std::unordered_map<uint64_t, WayRenderInfo> ways;
+		std::vector<VehicleRenderInfo> vehicles;
+
+		NodeRenderInfo* selectedNode = nullptr;
+	};
+
+} // namespace tjs::core::model
+
+namespace tjs {
+	class Application;
+} // namespace tjs
+
+namespace tjs::visualization {
+	void recalculate_map_data(Application& app);
+} // namespace tjs::visualization

--- a/CitySimulator/src/app/ui_system/debug_ui/map_analyzer_widget.cpp
+++ b/CitySimulator/src/app/ui_system/debug_ui/map_analyzer_widget.cpp
@@ -1,0 +1,37 @@
+#include "ui_system/debug_ui/map_analyzer_widget.h"
+#include "Application.h"
+#include "data/persistent_render_data.h"
+
+#include <QVBoxLayout>
+#include <QTimer>
+
+namespace tjs::ui {
+
+	MapAnalyzerWidget::MapAnalyzerWidget(Application& app)
+		: QWidget(nullptr)
+		, _application(app) {
+		QVBoxLayout* layout = new QVBoxLayout(this);
+		_nodeId = new QLabel("Node: none", this);
+		_coords = new QLabel("Coords: 0, 0", this);
+		layout->addWidget(_nodeId);
+		layout->addWidget(_coords);
+
+		QTimer* timer = new QTimer(this);
+		connect(timer, &QTimer::timeout, this, &MapAnalyzerWidget::updateInfo);
+		timer->start(200);
+	}
+
+	void MapAnalyzerWidget::updateInfo() {
+		auto* cache = _application.stores().get_model<core::model::PersistentRenderData>();
+		if (!cache || !cache->selectedNode) {
+			_nodeId->setText("Node: none");
+			_coords->setText("Coords: -");
+			return;
+		}
+
+		const auto* node = cache->selectedNode->node;
+		_nodeId->setText(QString("Node: %1").arg(node->uid));
+		_coords->setText(QString("Coords: %1, %2").arg(node->coordinates.latitude).arg(node->coordinates.longitude));
+	}
+
+} // namespace tjs::ui

--- a/CitySimulator/src/app/ui_system/debug_ui/map_analyzer_widget.h
+++ b/CitySimulator/src/app/ui_system/debug_ui/map_analyzer_widget.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QWidget>
+#include <QLabel>
+
+namespace tjs {
+	class Application;
+} // namespace tjs
+
+namespace tjs::ui {
+	class MapAnalyzerWidget : public QWidget {
+	public:
+		explicit MapAnalyzerWidget(Application& app);
+
+	private slots:
+		void updateInfo();
+
+	private:
+		Application& _application;
+		QLabel* _nodeId;
+		QLabel* _coords;
+	};
+} // namespace tjs::ui

--- a/CitySimulator/src/app/ui_system/qt_ui/map_control_widget.cpp
+++ b/CitySimulator/src/app/ui_system/qt_ui/map_control_widget.cpp
@@ -16,6 +16,7 @@
 #include "visualization/Scene.h"
 #include "visualization/scene_system.h"
 #include "visualization/elements/map_element.h"
+#include "data/persistent_render_data.h"
 
 #include <core/data_layer/world_creator.h>
 #include <core/simulation/simulation_system.h>
@@ -302,6 +303,7 @@ namespace tjs {
 			double currentZoom = render_data->metersPerPixel;
 			render_data->set_meters_per_pixel(currentZoom * 0.9); // Zoom in (decrease meters per pixel)
 			UpdateLabels();
+			visualization::recalculate_map_data(_application);
 		}
 
 		void MapControlWidget::onZoomOut() {
@@ -313,6 +315,7 @@ namespace tjs {
 			double currentZoom = render_data->metersPerPixel;
 			render_data->set_meters_per_pixel(currentZoom * 1.1); // Zoom out (increase meters per pixel)
 			UpdateLabels();
+			visualization::recalculate_map_data(_application);
 		}
 
 		double getChangedStep(double metersPerPixel) {
@@ -343,6 +346,7 @@ namespace tjs {
 				current.latitude += getChangedStep(render_data->metersPerPixel);
 				_latitude->setValue(current.latitude);
 				render_data->projectionCenter = current;
+				visualization::recalculate_map_data(_application);
 			}
 		}
 
@@ -357,6 +361,7 @@ namespace tjs {
 				current.latitude -= getChangedStep(render_data->metersPerPixel);
 				_latitude->setValue(current.latitude);
 				render_data->projectionCenter = current;
+				visualization::recalculate_map_data(_application);
 			}
 		}
 
@@ -371,6 +376,7 @@ namespace tjs {
 				current.longitude -= getChangedStep(render_data->metersPerPixel);
 				_longitude->setValue(current.longitude);
 				render_data->projectionCenter = current;
+				visualization::recalculate_map_data(_application);
 			}
 		}
 
@@ -385,6 +391,7 @@ namespace tjs {
 				current.longitude += getChangedStep(render_data->metersPerPixel);
 				_longitude->setValue(current.longitude);
 				render_data->projectionCenter = current;
+				visualization::recalculate_map_data(_application);
 			}
 		}
 
@@ -411,6 +418,7 @@ namespace tjs {
 			}
 			render_data->metersPerPixel = _application.settings().general.zoomLevel;
 			UpdateLabels();
+			visualization::recalculate_map_data(_application);
 
 			// Initialize spin boxes with current values
 			_latitude->setValue(render_data->projectionCenter.latitude);
@@ -432,6 +440,7 @@ namespace tjs {
 						mapElement->init();
 					}
 				}
+				visualization::recalculate_map_data(_application);
 				return true;
 			}
 			return false;

--- a/CitySimulator/src/app/ui_system/qt_ui/qt_controller.cpp
+++ b/CitySimulator/src/app/ui_system/qt_ui/qt_controller.cpp
@@ -15,6 +15,7 @@
 #include "ui_system/qt_ui/map_control_widget.h"
 #include "ui_system/qt_ui/time_control_widget.h"
 #include "ui_system/debug_ui/vehicle_analyze_widget.h"
+#include "ui_system/debug_ui/map_analyzer_widget.h"
 
 namespace tjs {
 	namespace ui {
@@ -72,6 +73,10 @@ namespace tjs {
 
 			MapControlWidget* mapControlWidget = new MapControlWidget(_application, scrollContent);
 			scrollLayout->addWidget(mapControlWidget);
+
+			MapAnalyzerWidget* analyzerWidget = new MapAnalyzerWidget(_application);
+			analyzerWidget->setParent(scrollContent);
+			scrollLayout->addWidget(analyzerWidget);
 
 			VehicleAnalyzeWidget* vehicleAnalyzeWidget = new VehicleAnalyzeWidget(_application);
 			vehicleAnalyzeWidget->setParent(scrollContent);

--- a/CitySimulator/src/app/visualization/elements/map_element.h
+++ b/CitySimulator/src/app/visualization/elements/map_element.h
@@ -3,7 +3,9 @@
 #include <visualization/scene_node.h>
 #include <core/data_layer/data_types.h>
 #include <data/map_renderer_data.h>
+#include <data/persistent_render_data.h>
 #include <core/data_layer/road_network.h>
+#include <visualization/map_render_events_listener.h>
 
 namespace tjs {
 	class Application;
@@ -14,6 +16,7 @@ namespace tjs::visualization {
 	class MapElement : public SceneNode {
 	public:
 		explicit MapElement(Application& application);
+		~MapElement();
 
 		void init() override;
 		void update() override;
@@ -23,7 +26,7 @@ namespace tjs::visualization {
 		Position convert_to_screen(const core::Coordinates& coord) const;
 		void auto_zoom(const std::unordered_map<uint64_t, std::unique_ptr<core::Node>>& nodes);
 		void calculate_map_bounds(const std::unordered_map<uint64_t, std::unique_ptr<core::Node>>& nodes);
-		int render_way(const core::WayInfo& way, const std::unordered_map<uint64_t, std::unique_ptr<core::Node>>& nodes);
+		int render_way(const core::model::WayRenderInfo& way);
 		void render_bounding_box() const;
 		void draw_lane_markers(const std::vector<Position>& nodes, int lanes, int lane_width_pixels);
 		void draw_path_nodes(const std::vector<Position>& nodes);
@@ -33,6 +36,8 @@ namespace tjs::visualization {
 
 		Application& _application;
 		core::model::MapRendererData& _render_data;
+		core::model::PersistentRenderData& _cache;
+		MapRenderEventsListener _listener;
 
 		// Bounding box coordinates
 		float min_lat = 0.0f;

--- a/CitySimulator/src/app/visualization/elements/vehicle_renderer.h
+++ b/CitySimulator/src/app/visualization/elements/vehicle_renderer.h
@@ -11,6 +11,7 @@ namespace tjs {
 
 		namespace model {
 			struct MapRendererData;
+			struct PersistentRenderData;
 		} // namespace model
 
 	} // namespace core
@@ -30,10 +31,11 @@ namespace tjs::visualization {
 		virtual void render(IRenderer& renderer) override;
 
 	private:
-		void render(IRenderer& renderer, const core::Vehicle& vehicle);
+		void render(IRenderer& renderer, const core::Vehicle& vehicle, const tjs::Position& pos);
 
 	private:
 		core::model::MapRendererData& _mapRendererData;
+		core::model::PersistentRenderData& _cache;
 		Application& _application;
 	};
 } // namespace tjs::visualization

--- a/CitySimulator/src/app/visualization/map_render_events_listener.cpp
+++ b/CitySimulator/src/app/visualization/map_render_events_listener.cpp
@@ -1,0 +1,48 @@
+#include "stdafx.h"
+#include "visualization/map_render_events_listener.h"
+#include "Application.h"
+#include "data/persistent_render_data.h"
+
+#include <cmath>
+
+namespace tjs::visualization {
+
+	MapRenderEventsListener::MapRenderEventsListener(Application& app, float maxDistance)
+		: _application(app)
+		, _maxDistance(maxDistance) {}
+
+	void MapRenderEventsListener::on_mouse_event(const render::RendererMouseEvent& event) {
+		if (event.button != render::RendererMouseEvent::ButtonType::Left || event.state != render::RendererMouseEvent::ButtonState::Pressed) {
+			return;
+		}
+
+		auto* cache = _application.stores().get_model<core::model::PersistentRenderData>();
+		if (!cache) {
+			return;
+		}
+
+		core::model::NodeRenderInfo* nearest = nullptr;
+		float bestDist = _maxDistance;
+		for (auto& [id, info] : cache->nodes) {
+			float dx = static_cast<float>(info.screenPos.x - event.x);
+			float dy = static_cast<float>(info.screenPos.y - event.y);
+			float dist = std::sqrt(dx * dx + dy * dy);
+			if (dist < bestDist) {
+				bestDist = dist;
+				nearest = &info;
+			}
+		}
+
+		if (cache->selectedNode) {
+			cache->selectedNode->selected = false;
+		}
+
+		if (nearest) {
+			nearest->selected = true;
+			cache->selectedNode = nearest;
+		} else {
+			cache->selectedNode = nullptr;
+		}
+	}
+
+} // namespace tjs::visualization

--- a/CitySimulator/src/app/visualization/map_render_events_listener.h
+++ b/CitySimulator/src/app/visualization/map_render_events_listener.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <render/render_events.h>
+
+namespace tjs {
+	class Application;
+} // namespace tjs
+
+namespace tjs::visualization {
+
+	class MapRenderEventsListener : public render::IRenderEventListener {
+	public:
+		MapRenderEventsListener(Application& app, float maxDistance = 10.0f);
+		void on_mouse_event(const render::RendererMouseEvent& event) override;
+
+	private:
+		Application& _application;
+		float _maxDistance;
+	};
+
+} // namespace tjs::visualization


### PR DESCRIPTION
## Summary
- store precomputed screen positions for nodes, ways and vehicles in new `PersistentRenderData`
- add event listener for map clicks to select nearest node
- render map and vehicles using cached positions
- display selected node information in new `MapAnalyzerWidget`
- update map controls to recalculate cache on view changes

## Testing
- `ci/format_all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684597eb7f608327bcfeb14ce9801104

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a persistent render cache for optimized map rendering and introduce a new MapAnalyzerWidget for visual analysis of map elements.

### Why are these changes being made?

These changes are made to improve the rendering performance by caching render data for nodes, ways, and vehicles, reducing redundant computations. Additionally, the introduction of the MapAnalyzerWidget enhances the user interface by providing real-time visual analysis tools to interact with map nodes more effectively, complementing the optimized rendering pipeline. This approach enhances overall application efficiency and usability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->