### PR TITLE
Add Tracy macros for profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@
 
 # installed packages
 /vcpkg_installed/*
+/tools/bin/*

--- a/CitySimulator/src/app/Application.cpp
+++ b/CitySimulator/src/app/Application.cpp
@@ -48,11 +48,12 @@ namespace tjs {
 		auto lastFrameTime = std::chrono::high_resolution_clock::now();
 		int currentFPS = 0.0;
 
-		auto lastTimeSaveSettings = lastFrameTime;
-		auto prevFrameStart = lastFrameTime;
-		while (!isFinished()) {
-			// Record the start time of this frame
-			auto frameStart = std::chrono::high_resolution_clock::now();
+        auto lastTimeSaveSettings = lastFrameTime;
+        auto prevFrameStart = lastFrameTime;
+        while (!isFinished()) {
+                TJS_TRACY_NAMED("MainLoop");
+                // Record the start time of this frame
+                auto frameStart = std::chrono::high_resolution_clock::now();
 
 			// Calculate time elapsed since last simulation update for simulation calculations
 			const double durationInSeconds = std::chrono::duration_cast<std::chrono::duration<double>>(
@@ -110,10 +111,11 @@ namespace tjs {
 			// Calculate how long to sleep to maintain target FPS
 			duration sleepTime = targetFrameTime - frameDuration;
 			// If we're running faster than the target FPS, sleep for the remaining time
-			if (sleepTime.count() > 0) {
-				std::this_thread::sleep_for(std::chrono::duration_cast<std::chrono::milliseconds>(sleepTime));
-			}
-		}
+                        if (sleepTime.count() > 0) {
+                                std::this_thread::sleep_for(std::chrono::duration_cast<std::chrono::milliseconds>(sleepTime));
+                        }
+                        TJS_FRAME_MARK;
+                }
 
 		// Save settings before quit
 		_settings.save();

--- a/CitySimulator/src/app/CMakeLists.txt
+++ b/CitySimulator/src/app/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(TJC_TJamApp PRIVATE
     Qt6::Gui
     Qt6::Widgets
     SDL3::SDL3
+    TracyClient
 )
 
 add_subdirectory(
@@ -38,11 +39,12 @@ SET(CMAKE_AUTOMOC   ON)
 SET(CMAKE_AUTOMOC_MOC_OPTIONS "-nw")
 
 # Specify the include directories for app
-target_include_directories(TJC_TJamApp PRIVATE 
+target_include_directories(TJC_TJamApp PRIVATE
     "${CMAKE_SOURCE_DIR}/CitySimulator/src/app"
     "${CMAKE_SOURCE_DIR}/CitySimulator/src/core/include"
     "${CMAKE_SOURCE_DIR}/CitySimulator/src/common/include"
     ${JSON_INCLUDE_DIR}
+    ${TRACY_INCLUDE_DIR}
 )
 
 # Set platform-specific flags for app if necessary
@@ -51,3 +53,5 @@ if(WIN32)
 elseif(APPLE)
     target_compile_definitions(TJC_TJamApp PRIVATE "PLATFORM_MAC")
 endif()
+
+target_compile_definitions(TJC_TJamApp PRIVATE TRACY_ENABLED)

--- a/CitySimulator/src/app/stdafx.h
+++ b/CitySimulator/src/app/stdafx.h
@@ -16,3 +16,16 @@
 #include <ranges>
 #include <concepts>
 #include <utility>
+
+#ifdef TRACY_ENABLED
+#  define TRACY_ENABLE
+#  include <Tracy.hpp>
+
+#  define TJS_TRACY ZoneScoped
+#  define TJS_TRACY_NAMED(NAME) ZoneScopedN(NAME)
+#  define TJS_FRAME_MARK FrameMark
+#else
+#  define TJS_TRACY
+#  define TJS_TRACY_NAMED(NAME)
+#  define TJS_FRAME_MARK
+#endif

--- a/sdks/CMakeLists.txt
+++ b/sdks/CMakeLists.txt
@@ -18,3 +18,5 @@ if (WITH_TESTS)
     add_subdirectory(gtest)
     set_target_properties(gtest PROPERTIES FOLDER "sdks")
 endif()
+
+add_subdirectory(tracy)

--- a/sdks/tracy/CMakeLists.txt
+++ b/sdks/tracy/CMakeLists.txt
@@ -1,0 +1,16 @@
+include(FetchContent)
+
+FetchContent_Declare(
+    tracy
+    GIT_REPOSITORY https://github.com/wolfpld/tracy.git
+    GIT_TAG master
+)
+
+FetchContent_MakeAvailable(tracy)
+
+if(TARGET TracyClient)
+    set_target_properties(TracyClient PROPERTIES FOLDER "sdks")
+endif()
+
+set(TRACY_INCLUDE_DIR ${tracy_SOURCE_DIR}/public CACHE PATH INTERNAL)
+set(TRACY_LIB_DIR ${tracy_BINARY_DIR} CACHE PATH INTERNAL)

--- a/tools/download_tracy.sh
+++ b/tools/download_tracy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+TARGET_DIR="${SCRIPT_DIR}/bin"
+mkdir -p "${TARGET_DIR}"
+
+# Determine OS
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     os='linux64';;
+    Darwin*)    os='macos';;
+    CYGWIN*|MINGW*) os='win64';;
+    *)          os='';;
+esac
+
+if [ -z "$os" ]; then
+    echo "Unsupported operating system: ${unameOut}"
+    exit 1
+fi
+
+VERSION=${1:-0.10}
+ARCHIVE="tracy-${VERSION}-${os}"
+URL="https://github.com/wolfpld/tracy/releases/download/v${VERSION}/${ARCHIVE}.zip"
+
+echo "Downloading ${URL}..."
+
+curl -L "$URL" -o "${TARGET_DIR}/${ARCHIVE}.zip"
+
+unzip -o "${TARGET_DIR}/${ARCHIVE}.zip" -d "${TARGET_DIR}"
+rm "${TARGET_DIR}/${ARCHIVE}.zip"
+
+echo "Tracy downloaded to ${TARGET_DIR}"


### PR DESCRIPTION
## Summary
- wrap Tracy instrumentation in helper macros
- use the macros in the main loop
- switch app to `TRACY_ENABLED` compile definition

## Testing
- `cmake -S . -B build -G Ninja` *(fails: unable to clone tracy repo)*
- `cmake --build build` *(fails: build.ninja not generated)*
- `ctest --test-dir build` *(no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68568bc2e81c8327b991853e0ba97f3b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Integrate Tracy library for profiling and performance analysis by adding related macro definitions, scripts, and CMake configuration.

### Why are these changes being made?

This integration introduces tools for detailed CPU and GPU profiling to improve performance analysis and debugging capabilities. The selected approach of using Tracy is due to its non-intrusive instrumentation features and comprehensive profiling tools for real-time applications, which are directly beneficial for optimizing the CitySimulator application's performance.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->