### PR TITLE
Add window geometry persistence and simulation pause setting

### DIFF
--- a/CitySimulator/src/app/render/render_primitives.h
+++ b/CitySimulator/src/app/render/render_primitives.h
@@ -67,6 +67,12 @@ namespace tjs {
 			, y(y_)
 			, width(width_)
 			, height(height_) {}
+
+		NLOHMANN_DEFINE_TYPE_INTRUSIVE(Rectangle,
+			x,
+			y,
+			width,
+			height);
 	};
 	static_assert(sizeof(Rectangle) == 16, "Rectangle should be 16 bytes");
 

--- a/CitySimulator/src/app/settings/general_settings.h
+++ b/CitySimulator/src/app/settings/general_settings.h
@@ -10,11 +10,15 @@ namespace tjs::settings {
 		std::string selectedFile;
 		tjs::Position screen_center;
 		double zoomLevel;
+		tjs::Rectangle qt_window { 0, 0, 700, 800 };
+		tjs::Rectangle sdl_window { 0, 0, 1024, 768 };
 
 		static constexpr const char* NAME = "General";
 		NLOHMANN_DEFINE_TYPE_INTRUSIVE(GeneralSettings,
 			selectedFile,
 			screen_center,
-			zoomLevel)
+			zoomLevel,
+			qt_window,
+			sdl_window)
 	};
 } // namespace tjs::settings

--- a/CitySimulator/src/app/ui_system/qt_ui/main_window.cpp
+++ b/CitySimulator/src/app/ui_system/qt_ui/main_window.cpp
@@ -17,6 +17,12 @@ namespace tjs {
 		}
 
 		void MainWindow::closeEvent(QCloseEvent* event) {
+			auto& win = _app.settings().general.qt_window;
+			const QRect geom = geometry();
+			win.x = geom.x();
+			win.y = geom.y();
+			win.width = geom.width();
+			win.height = geom.height();
 			_app.setFinished();
 		}
 	} // namespace ui

--- a/CitySimulator/src/app/ui_system/qt_ui/qt_controller.cpp
+++ b/CitySimulator/src/app/ui_system/qt_ui/qt_controller.cpp
@@ -50,8 +50,15 @@ namespace tjs {
 			window->setWindowTitle("TJS");
 
 			const auto& win_settings = _application.settings().general.qt_window;
-			window->resize(win_settings.width, win_settings.height);
-			window->move(win_settings.x, win_settings.y);
+			const int MIN_WIDTH = 200;
+			const int MIN_HEIGHT = 200;
+			window->resize(std::max(win_settings.width, MIN_WIDTH), std::max(win_settings.height, MIN_HEIGHT));
+			window->setMinimumSize(MIN_WIDTH, MIN_HEIGHT);
+
+			QRect screenGeometry = QApplication::primaryScreen()->availableGeometry();
+			int x = std::clamp(win_settings.x, 0, screenGeometry.width() - win_settings.width);
+			int y = std::clamp(win_settings.y, 0, screenGeometry.height() - win_settings.height);
+			window->move(x, y);
 
 			// Create main widget to hold everything
 			QWidget* mainWidget = new QWidget(window);

--- a/CitySimulator/src/app/ui_system/qt_ui/qt_controller.cpp
+++ b/CitySimulator/src/app/ui_system/qt_ui/qt_controller.cpp
@@ -48,7 +48,10 @@ namespace tjs {
 			// Create main window
 			MainWindow* window = new MainWindow(_application);
 			window->setWindowTitle("TJS");
-			window->resize(700, 800);
+
+			const auto& win_settings = _application.settings().general.qt_window;
+			window->resize(win_settings.width, win_settings.height);
+			window->move(win_settings.x, win_settings.y);
 
 			// Create main widget to hold everything
 			QWidget* mainWidget = new QWidget(window);

--- a/CitySimulator/src/app/ui_system/qt_ui/time_control_widget.cpp
+++ b/CitySimulator/src/app/ui_system/qt_ui/time_control_widget.cpp
@@ -88,6 +88,7 @@ namespace tjs {
 				_startPauseButton->setText("Pause");
 			}
 			_isRunning = !_isRunning;
+			_application.settings().simulationSettings.simulation_paused = !_isRunning;
 			updateButtonStates();
 		}
 

--- a/CitySimulator/src/app/ui_system/qt_ui/time_control_widget.cpp
+++ b/CitySimulator/src/app/ui_system/qt_ui/time_control_widget.cpp
@@ -27,7 +27,8 @@ namespace tjs {
 			// Create start/pause button
 			_startPauseButton = new QPushButton("Start", this);
 			connect(_startPauseButton, &QPushButton::clicked, this, &TimeControlWidget::onStartPauseClicked);
-			_isRunning = !_application.simulationSystem().timeModule().state().isPaused;
+			_isRunning = !_application.simulationSystem().timeModule().state().isPaused && !_application.simulationSystem().settings().simulation_paused;
+
 			_startPauseButton->setText(_isRunning ? "Pause" : "Start");
 			layout->addWidget(_startPauseButton);
 

--- a/CitySimulator/src/core/include/core/simulation/simulation_settings.h
+++ b/CitySimulator/src/core/include/core/simulation/simulation_settings.h
@@ -16,13 +16,15 @@ namespace tjs::core {
 		size_t vehiclesCount = DEFAULT_VEHICLES_COUNT;
 		int steps_on_update = DEFAULT_STEPS_ON_UPDATE;
 		double step_delta_sec = DEFAULT_FIXED_STEP_SEC;
+		bool simulation_paused = true;
 
 		NLOHMANN_DEFINE_TYPE_INTRUSIVE(SimulationSettings,
 			randomSeed,
 			seedValue,
 			vehiclesCount,
 			steps_on_update,
-			step_delta_sec);
+			step_delta_sec,
+			simulation_paused);
 	};
 
 } // namespace tjs::core

--- a/CitySimulator/src/core/src/simulation/simulation_system.cpp
+++ b/CitySimulator/src/core/src/simulation/simulation_system.cpp
@@ -49,7 +49,7 @@ namespace tjs::core::simulation {
 		_tacticalModule.initialize();
 		_vehicleMovementModule.initialize();
 
-		if (!_settings.simulation_paused) {
+		if (_settings.simulation_paused) {
 			_timeModule.pause();
 		}
 

--- a/CitySimulator/src/core/src/simulation/simulation_system.cpp
+++ b/CitySimulator/src/core/src/simulation/simulation_system.cpp
@@ -49,6 +49,10 @@ namespace tjs::core::simulation {
 		_tacticalModule.initialize();
 		_vehicleMovementModule.initialize();
 
+		if (!_settings.simulation_paused) {
+			_timeModule.pause();
+		}
+
 		if (_agents.size() == 1) {
 			_store.get_entry<core::model::VehicleAnalyzeData>()->agent = &_agents[0];
 		}


### PR DESCRIPTION
## Summary
- remember Qt and SDL window geometry in settings
- add `simulation_paused` field to simulation settings
- respect `simulation_paused` on initialization
- track window positions and sizes at runtime
- keep pause state in settings when toggled

## Testing
- `./ci/format_changed.sh`
- `cmake -S . -B build -DWITH_TESTS=ON` *(fails: unable to download tracy)*

------
https://chatgpt.com/codex/tasks/task_e_6885141dd430832797ef1f300849ee8f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add window geometry persistence and simulation pause setting to SDL and Qt windows, along with the capability to store and restore window positions and dimensions, and integrate the simulation paused status into application settings.

### Why are these changes being made?
These changes improve user experience by saving window states, so users have a consistent view when restarting the application. They also offer finer control over simulations by pausing or continuing them based on user convenience or preference, which is efficiently managed through the application's settings.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->